### PR TITLE
fix: ios build number as string

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,7 +83,7 @@ export function setIOSBuild(options: { dir: string; build: number }): void {
   const file = fs.readFileSync(options.dir + iosFile, 'utf-8');
   const parsed = plist.parse(file) as any;
 
-  parsed.CFBundleVersion = options.build;
+  parsed.CFBundleVersion = options.build.toString();
 
   const result = plist.build(parsed);
   fs.writeFileSync(options.dir + iosFile, result, 'utf-8');

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@oclif/test';
 import { resolve } from 'path';
 import * as mockfs from 'mock-fs';
+import * as fs from 'fs';
 
 import * as utils from '../src/utils';
 
@@ -103,6 +104,17 @@ describe('capacitor-set-version', () => {
       utils.setIOSBuild({ dir: path, build: 10 });
       const build = utils.getIOSBuild({ dir: path });
       expect(build).equals(10);
+    });
+
+    // Fix #159
+    it('should set ios build as string', () => {
+      utils.setIOSBuild({ dir: path, build: 10 });
+
+      const file = fs.readFileSync(path + '/ios/App/App/Info.plist', 'utf-8');
+
+      const ok = file.includes('<string>10</string>');
+
+      expect(ok).to.be.true;
     });
 
     it('should return null when dir is invalid', () => {


### PR DESCRIPTION
Fix #159