### PR TITLE
Change Android versionName replacement regex to prevent changes to versionNameSuffix

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export function getAndroidVersion(options: { dir: string }): string | null {
 
 export function setAndroidVersion(options: { dir: string; version: string }): void {
   const file = fs.readFileSync(options.dir + androidFile, 'utf-8');
-  const result = file.replace(/(.*(?:versionName).*)/g, `        versionName "${options.version}"`);
+  const result = file.replace(/(.*(?:versionName[ \t]+).*)/g, `        versionName "${options.version}"`);
   fs.writeFileSync(options.dir + androidFile, result, 'utf-8');
 }
 


### PR DESCRIPTION
I am using Android product flavors in my gradle build scripts. Product flavor builds can optionally append a suffix to a global `versionName` string when configured with `versionNameSuffix` property.

`capacitor-set-version` plugin correctly updates the global `versionName` property but unfortunately replaces all `versionNameSuffix` properties with `versionName: VERSION` due to broad regex for replacement.

This pull request prevents `capacitor-set-version` from replacing `versionNameSuffix` properties in product flavors by narrowing down the replacement regex. A mandatory empty space ([ \t]+) is added to the `versionName` capture group.