### PR TITLE
fix: cfbundleversion as string for legacy ios projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-set-version",
-  "version": "1.3.37",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-set-version",
-      "version": "1.3.37",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^1",

--- a/src/common/utils-ios.ts
+++ b/src/common/utils-ios.ts
@@ -124,5 +124,5 @@ function setIOSVersionLegacy(infoPlist: any, version: string) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setIOSBuildLegacy(infoPlist: any, build: number) {
-  infoPlist.CFBundleVersion = build;
+  infoPlist.CFBundleVersion = build.toString();
 }

--- a/test/commands/set/index.test.ts
+++ b/test/commands/set/index.test.ts
@@ -1,6 +1,8 @@
 import { VersionInfo } from '../../../src/common/version-info.type';
 import MockFsFactory from '../../mockfs/mockfs.factory';
 
+import * as fs from 'fs';
+
 const versionInfo: VersionInfo = {
   version: '1.5.0-rc1',
   build: 150,
@@ -217,5 +219,18 @@ describe('when capacitor-set-version is called', () => {
         expect(err.message).to.contain('Could not find "CURRENT_PROJECT_VERSION" in project.pbxproj file');
       })
       .it('should error');
+  });
+
+  describe('for legacy ios project,', () => {
+    test
+      .command(['set:ios', '-v', versionInfo.version, '-b', versionInfo.build.toString(), MockFsFactory.DIR_IOS_LEGACY])
+      .it('should set CFBundleVersion with type string (#215)', () => {
+        const expectedCFBundleVersion = '<string>150</string>';
+        const infoPlistFile = fs
+          .readFileSync(MockFsFactory.DIR_IOS_LEGACY + '/ios/App/App/Info.plist')
+          .toString('utf8');
+
+        expect(infoPlistFile).to.contain(expectedCFBundleVersion);
+      });
   });
 });


### PR DESCRIPTION
Closes #215 