### PR TITLE
feat(kotlin support): add support for kotlin DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 node_modules
 oclif.manifest.json
 tsconfig.tsbuildinfo
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-set-version",
-  "version": "2.0.11",
+  "version": "2.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-set-version",
-      "version": "2.0.11",
+      "version": "2.0.13",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^1",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@babel/eslint-parser/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1605,6 +1605,41 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+      "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.2.tgz",
@@ -1869,22 +1904,22 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+      "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
         "execa": "^5.0.0",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^11.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
         "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
-        "registry-auth-token": "^4.0.0",
+        "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
         "tempy": "^1.0.0"
       },
@@ -1893,6 +1928,20 @@
       },
       "peerDependencies": {
         "semantic-release": ">=19.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
@@ -2681,10 +2730,22 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/aws-sdk": {
-      "version": "2.1131.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1131.0.tgz",
-      "integrity": "sha512-Ic3f2fSgVhYDQ0OBGxE6ODtSwaKyxBPGrI2RGrYt2Oj0Z8f227P7dB90o9X7y2MtnuJ4WoAzkf3Vc1c1UnnZlA==",
+      "version": "2.1463.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1463.0.tgz",
+      "integrity": "sha512-NGJLovoHEX6uN3u9iHx0KWg9AigZfSz9YekLQssqGk5vHAEzW7TlCgRsqTu6vhGI5FzlYWapSvUpJUriQUCwMA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2694,21 +2755,21 @@
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/aws-sdk/node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
       "dev": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/balanced-match": {
@@ -2997,6 +3058,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3452,6 +3526,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
@@ -3523,9 +3607,9 @@
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4482,9 +4566,9 @@
       }
     },
     "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5071,6 +5155,15 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -5223,6 +5316,21 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -5416,6 +5524,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -5510,6 +5630,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -5578,9 +5737,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-call": {
@@ -5865,6 +6024,22 @@
       "integrity": "sha512-SLm2ERgmBGag79RfrIknk+40ZOJCgUBpCQTl3WE2YER21VR0W3Vt/OAXXaYLSU0AIcBqWnytoTwk2ZcTbxH0xg==",
       "dev": true
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5892,6 +6067,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -5934,6 +6121,21 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -6058,6 +6260,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -6178,9 +6395,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -6361,9 +6578,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -6624,9 +6841,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -7541,9 +7758,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.16.0.tgz",
-      "integrity": "sha512-UfLT/hCbcpV9uiTEBthyrOlQxwk8LG5tAGn283g7f7pRx41KcwFiHV7HYgYm2y2GabfnPtf897ptrXRQwxJWzQ==",
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7562,6 +7779,7 @@
         "cli-table3",
         "columnify",
         "fastest-levenshtein",
+        "fs-minipass",
         "glob",
         "graceful-fs",
         "hosted-git-info",
@@ -7581,6 +7799,7 @@
         "libnpmteam",
         "libnpmversion",
         "make-fetch-happen",
+        "minimatch",
         "minipass",
         "minipass-pipeline",
         "mkdirp",
@@ -7620,64 +7839,66 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.2.0",
+        "@npmcli/config": "^4.2.1",
         "@npmcli/fs": "^2.1.0",
         "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^4.2.0",
+        "@npmcli/run-script": "^4.2.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.1.1",
+        "cacache": "^16.1.3",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
+        "fs-minipass": "^2.1.0",
         "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.0.0",
-        "ini": "^3.0.0",
+        "hosted-git-info": "^5.2.1",
+        "ini": "^3.0.1",
         "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.2",
-        "libnpmdiff": "^4.0.2",
-        "libnpmexec": "^4.0.2",
-        "libnpmfund": "^3.0.1",
-        "libnpmhook": "^8.0.2",
-        "libnpmorg": "^4.0.2",
-        "libnpmpack": "^4.0.2",
-        "libnpmpublish": "^6.0.2",
-        "libnpmsearch": "^5.0.2",
-        "libnpmteam": "^4.0.2",
-        "libnpmversion": "^3.0.1",
+        "libnpmaccess": "^6.0.4",
+        "libnpmdiff": "^4.0.5",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
+        "libnpmhook": "^8.0.4",
+        "libnpmorg": "^4.0.4",
+        "libnpmpack": "^4.1.3",
+        "libnpmpublish": "^6.0.5",
+        "libnpmsearch": "^5.0.4",
+        "libnpmteam": "^4.0.4",
+        "libnpmversion": "^3.0.7",
         "make-fetch-happen": "^10.2.0",
+        "minimatch": "^5.1.0",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.0.0",
-        "nopt": "^5.0.0",
+        "node-gyp": "^9.1.0",
+        "nopt": "^6.0.0",
         "npm-audit-report": "^3.0.0",
         "npm-install-checks": "^5.0.0",
         "npm-package-arg": "^9.1.0",
-        "npm-pick-manifest": "^7.0.1",
+        "npm-pick-manifest": "^7.0.2",
         "npm-profile": "^6.2.0",
-        "npm-registry-fetch": "^13.3.0",
+        "npm-registry-fetch": "^13.3.1",
         "npm-user-validate": "^1.0.1",
         "npmlog": "^6.0.2",
         "opener": "^1.5.2",
         "p-map": "^4.0.0",
-        "pacote": "^13.6.1",
+        "pacote": "^13.6.2",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^5.0.1",
+        "read-package-json": "^5.0.2",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
@@ -7696,7 +7917,7 @@
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm-bundled": {
@@ -8006,7 +8227,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.4.0",
+      "version": "5.6.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8019,20 +8240,21 @@
         "@npmcli/name-from-folder": "^1.0.1",
         "@npmcli/node-gyp": "^2.0.0",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/query": "^1.1.1",
+        "@npmcli/query": "^1.2.0",
         "@npmcli/run-script": "^4.1.3",
-        "bin-links": "^3.0.0",
-        "cacache": "^16.0.6",
+        "bin-links": "^3.0.3",
+        "cacache": "^16.1.3",
         "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^5.2.1",
         "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
         "minimatch": "^5.1.0",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
+        "nopt": "^6.0.0",
         "npm-install-checks": "^5.0.0",
         "npm-package-arg": "^9.0.0",
-        "npm-pick-manifest": "^7.0.0",
+        "npm-pick-manifest": "^7.0.2",
         "npm-registry-fetch": "^13.0.0",
         "npmlog": "^6.0.2",
         "pacote": "^13.6.1",
@@ -8065,7 +8287,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "4.2.0",
+      "version": "4.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8073,7 +8295,7 @@
         "@npmcli/map-workspaces": "^2.0.2",
         "ini": "^3.0.0",
         "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
+        "nopt": "^6.0.0",
         "proc-log": "^2.0.0",
         "read-package-json-fast": "^2.0.3",
         "semver": "^7.3.5",
@@ -8096,7 +8318,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8109,7 +8331,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8144,8 +8366,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8175,7 +8406,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8227,7 +8458,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8241,7 +8472,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "4.2.0",
+      "version": "4.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8347,7 +8578,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8356,7 +8587,7 @@
         "readable-stream": "^3.6.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/asap": {
@@ -8372,18 +8603,27 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "3.0.1",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cmd-shim": "^5.0.0",
         "mkdirp-infer-owner": "^2.0.0",
-        "npm-normalize-package-bin": "^1.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
         "read-cmd-shim": "^3.0.0",
         "rimraf": "^3.0.0",
         "write-file-atomic": "^4.0.0"
       },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
@@ -8416,7 +8656,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.1.1",
+      "version": "16.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8438,7 +8678,7 @@
         "rimraf": "^3.0.2",
         "ssri": "^9.0.0",
         "tar": "^6.1.11",
-        "unique-filename": "^1.1.1"
+        "unique-filename": "^2.0.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -8676,7 +8916,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.0.0",
+      "version": "5.1.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -8817,7 +9057,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "5.0.0",
+      "version": "5.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8825,11 +9065,11 @@
         "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
@@ -8936,7 +9176,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8963,7 +9203,7 @@
       }
     },
     "node_modules/npm/node_modules/ip": {
-      "version": "1.1.8",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -8990,7 +9230,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.9.0",
+      "version": "2.10.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9047,19 +9287,19 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "5.0.3",
+      "version": "5.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.3.1",
+      "version": "5.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9074,7 +9314,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "4.0.4",
+      "version": "4.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9082,7 +9322,7 @@
         "@npmcli/disparity-colors": "^2.0.0",
         "@npmcli/installed-package-contents": "^1.0.7",
         "binary-extensions": "^2.2.0",
-        "diff": "^5.0.0",
+        "diff": "^5.1.0",
         "minimatch": "^5.0.1",
         "npm-package-arg": "^9.0.1",
         "pacote": "^13.6.1",
@@ -9093,12 +9333,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.9",
+      "version": "4.0.14",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.0.0",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
         "@npmcli/fs": "^2.1.1",
         "@npmcli/run-script": "^4.2.0",
@@ -9118,19 +9358,19 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "3.0.2",
+      "version": "3.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.0.0"
+        "@npmcli/arborist": "^5.6.3"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9143,7 +9383,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9156,7 +9396,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "4.1.2",
+      "version": "4.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9170,7 +9410,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "6.0.4",
+      "version": "6.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9186,7 +9426,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9198,7 +9438,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9211,7 +9451,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "3.0.6",
+      "version": "3.0.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9227,7 +9467,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.12.0",
+      "version": "7.13.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9236,7 +9476,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "10.2.0",
+      "version": "10.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9299,7 +9539,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9422,7 +9662,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.0.0",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9487,7 +9727,7 @@
         "node": "*"
       }
     },
-    "node_modules/npm/node_modules/nopt": {
+    "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
@@ -9502,8 +9742,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -9514,7 +9769,7 @@
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
@@ -9530,12 +9785,24 @@
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "1.1.2",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
@@ -9572,15 +9839,15 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.1.1",
+      "version": "5.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^8.0.1",
         "ignore-walk": "^5.0.1",
-        "npm-bundled": "^1.1.2",
-        "npm-normalize-package-bin": "^1.0.1"
+        "npm-bundled": "^2.0.0",
+        "npm-normalize-package-bin": "^2.0.0"
       },
       "bin": {
         "npm-packlist": "bin/index.js"
@@ -9589,17 +9856,35 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-install-checks": "^5.0.0",
-        "npm-normalize-package-bin": "^1.0.1",
+        "npm-normalize-package-bin": "^2.0.0",
         "npm-package-arg": "^9.0.0",
         "semver": "^7.3.5"
       },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
@@ -9618,7 +9903,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.3.0",
+      "version": "13.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9690,7 +9975,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "13.6.1",
+      "version": "13.6.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9845,7 +10130,7 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "5.0.1",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9853,7 +10138,7 @@
         "glob": "^8.0.1",
         "json-parse-even-better-errors": "^2.3.1",
         "normalize-package-data": "^4.0.0",
-        "npm-normalize-package-bin": "^1.0.1"
+        "npm-normalize-package-bin": "^2.0.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -9870,6 +10155,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
@@ -10041,12 +10335,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.6.2",
+      "version": "2.7.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^1.1.5",
+        "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -10198,21 +10492,27 @@
       }
     },
     "node_modules/npm/node_modules/unique-filename": {
-      "version": "1.1.1",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-slug": {
-      "version": "2.0.2",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -10289,7 +10589,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10298,7 +10598,7 @@
         "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -10960,9 +11260,9 @@
       }
     },
     "node_modules/password-prompt/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -11424,6 +11724,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -11679,9 +11985,9 @@
       }
     },
     "node_modules/qqjs/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -11830,7 +12136,7 @@
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11970,9 +12276,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -12081,15 +12387,15 @@
       }
     },
     "node_modules/registry-auth-token": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+      "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
       "dev": true,
       "dependencies": {
-        "rc": "^1.2.8"
+        "@pnpm/npm-conf": "^2.1.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/release-zalgo": {
@@ -12299,7 +12605,7 @@
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
       "dev": true
     },
     "node_modules/scoped-regex": {
@@ -12372,9 +12678,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12398,9 +12704,9 @@
       }
     },
     "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -13549,6 +13855,19 @@
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13703,6 +14022,25 @@
         "node": ">=8.15"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -13724,9 +14062,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -13808,19 +14146,22 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xml2js/node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -14390,9 +14731,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -14415,9 +14756,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -14446,9 +14787,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -15595,6 +15936,32 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true
+    },
+    "@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.2.10"
+      }
+    },
+    "@pnpm/npm-conf": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+      "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+      "dev": true,
+      "requires": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      }
+    },
     "@semantic-release/changelog": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.2.tgz",
@@ -15797,24 +16164,37 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+      "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
         "execa": "^5.0.0",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^11.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
         "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
-        "registry-auth-token": "^4.0.0",
+        "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
         "tempy": "^1.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "@semantic-release/release-notes-generator": {
@@ -16390,10 +16770,16 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
+    },
     "aws-sdk": {
-      "version": "2.1131.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1131.0.tgz",
-      "integrity": "sha512-Ic3f2fSgVhYDQ0OBGxE6ODtSwaKyxBPGrI2RGrYt2Oj0Z8f227P7dB90o9X7y2MtnuJ4WoAzkf3Vc1c1UnnZlA==",
+      "version": "2.1463.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1463.0.tgz",
+      "integrity": "sha512-NGJLovoHEX6uN3u9iHx0KWg9AigZfSz9YekLQssqGk5vHAEzW7TlCgRsqTu6vhGI5FzlYWapSvUpJUriQUCwMA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -16403,14 +16789,15 @@
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
       },
       "dependencies": {
         "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
           "dev": true
         }
       }
@@ -16621,6 +17008,16 @@
         "make-dir": "^3.0.0",
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -16960,6 +17357,16 @@
         }
       }
     },
+    "config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "confusing-browser-globals": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
@@ -17016,9 +17423,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -17727,9 +18134,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -18147,6 +18554,15 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -18258,6 +18674,18 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -18400,6 +18828,15 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -18467,6 +18904,27 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -18519,9 +18977,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-call": {
@@ -18743,6 +19201,16 @@
       "integrity": "sha512-SLm2ERgmBGag79RfrIknk+40ZOJCgUBpCQTl3WE2YER21VR0W3Vt/OAXXaYLSU0AIcBqWnytoTwk2ZcTbxH0xg==",
       "dev": true
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -18765,6 +19233,12 @@
       "requires": {
         "builtin-modules": "^3.0.0"
       }
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
     },
     "is-core-module": {
       "version": "2.9.0",
@@ -18789,6 +19263,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -18871,6 +19354,15 @@
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
+      "requires": {
+        "which-typed-array": "^1.1.11"
       }
     },
     "is-typedarray": {
@@ -18963,9 +19455,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -19108,9 +19600,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -19317,9 +19809,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -20010,70 +20502,72 @@
       "dev": true
     },
     "npm": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.16.0.tgz",
-      "integrity": "sha512-UfLT/hCbcpV9uiTEBthyrOlQxwk8LG5tAGn283g7f7pRx41KcwFiHV7HYgYm2y2GabfnPtf897ptrXRQwxJWzQ==",
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.2.0",
+        "@npmcli/config": "^4.2.1",
         "@npmcli/fs": "^2.1.0",
         "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^4.2.0",
+        "@npmcli/run-script": "^4.2.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.1.1",
+        "cacache": "^16.1.3",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
+        "fs-minipass": "^2.1.0",
         "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.0.0",
-        "ini": "^3.0.0",
+        "hosted-git-info": "^5.2.1",
+        "ini": "^3.0.1",
         "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.2",
-        "libnpmdiff": "^4.0.2",
-        "libnpmexec": "^4.0.2",
-        "libnpmfund": "^3.0.1",
-        "libnpmhook": "^8.0.2",
-        "libnpmorg": "^4.0.2",
-        "libnpmpack": "^4.0.2",
-        "libnpmpublish": "^6.0.2",
-        "libnpmsearch": "^5.0.2",
-        "libnpmteam": "^4.0.2",
-        "libnpmversion": "^3.0.1",
+        "libnpmaccess": "^6.0.4",
+        "libnpmdiff": "^4.0.5",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
+        "libnpmhook": "^8.0.4",
+        "libnpmorg": "^4.0.4",
+        "libnpmpack": "^4.1.3",
+        "libnpmpublish": "^6.0.5",
+        "libnpmsearch": "^5.0.4",
+        "libnpmteam": "^4.0.4",
+        "libnpmversion": "^3.0.7",
         "make-fetch-happen": "^10.2.0",
+        "minimatch": "^5.1.0",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.0.0",
-        "nopt": "^5.0.0",
+        "node-gyp": "^9.1.0",
+        "nopt": "^6.0.0",
         "npm-audit-report": "^3.0.0",
         "npm-install-checks": "^5.0.0",
         "npm-package-arg": "^9.1.0",
-        "npm-pick-manifest": "^7.0.1",
+        "npm-pick-manifest": "^7.0.2",
         "npm-profile": "^6.2.0",
-        "npm-registry-fetch": "^13.3.0",
+        "npm-registry-fetch": "^13.3.1",
         "npm-user-validate": "^1.0.1",
         "npmlog": "^6.0.2",
         "opener": "^1.5.2",
         "p-map": "^4.0.0",
-        "pacote": "^13.6.1",
+        "pacote": "^13.6.2",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^5.0.1",
+        "read-package-json": "^5.0.2",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
@@ -20105,7 +20599,7 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "5.4.0",
+          "version": "5.6.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20117,20 +20611,21 @@
             "@npmcli/name-from-folder": "^1.0.1",
             "@npmcli/node-gyp": "^2.0.0",
             "@npmcli/package-json": "^2.0.0",
-            "@npmcli/query": "^1.1.1",
+            "@npmcli/query": "^1.2.0",
             "@npmcli/run-script": "^4.1.3",
-            "bin-links": "^3.0.0",
-            "cacache": "^16.0.6",
+            "bin-links": "^3.0.3",
+            "cacache": "^16.1.3",
             "common-ancestor-path": "^1.0.1",
+            "hosted-git-info": "^5.2.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
             "minimatch": "^5.1.0",
             "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
-            "nopt": "^5.0.0",
+            "nopt": "^6.0.0",
             "npm-install-checks": "^5.0.0",
             "npm-package-arg": "^9.0.0",
-            "npm-pick-manifest": "^7.0.0",
+            "npm-pick-manifest": "^7.0.2",
             "npm-registry-fetch": "^13.0.0",
             "npmlog": "^6.0.2",
             "pacote": "^13.6.1",
@@ -20153,14 +20648,14 @@
           "dev": true
         },
         "@npmcli/config": {
-          "version": "4.2.0",
+          "version": "4.2.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/map-workspaces": "^2.0.2",
             "ini": "^3.0.0",
             "mkdirp-infer-owner": "^2.0.0",
-            "nopt": "^5.0.0",
+            "nopt": "^6.0.0",
             "proc-log": "^2.0.0",
             "read-package-json-fast": "^2.0.3",
             "semver": "^7.3.5",
@@ -20176,7 +20671,7 @@
           }
         },
         "@npmcli/fs": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20185,7 +20680,7 @@
           }
         },
         "@npmcli/git": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20207,10 +20702,20 @@
           "requires": {
             "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
+          },
+          "dependencies": {
+            "npm-bundled": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            }
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20232,7 +20737,7 @@
           }
         },
         "@npmcli/move-file": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20267,7 +20772,7 @@
           }
         },
         "@npmcli/query": {
-          "version": "1.1.1",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20277,7 +20782,7 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20349,7 +20854,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20368,16 +20873,23 @@
           "dev": true
         },
         "bin-links": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "cmd-shim": "^5.0.0",
             "mkdirp-infer-owner": "^2.0.0",
-            "npm-normalize-package-bin": "^1.0.0",
+            "npm-normalize-package-bin": "^2.0.0",
             "read-cmd-shim": "^3.0.0",
             "rimraf": "^3.0.0",
             "write-file-atomic": "^4.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "binary-extensions": {
@@ -20402,7 +20914,7 @@
           }
         },
         "cacache": {
-          "version": "16.1.1",
+          "version": "16.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20423,7 +20935,7 @@
             "rimraf": "^3.0.2",
             "ssri": "^9.0.0",
             "tar": "^6.1.11",
-            "unique-filename": "^1.1.1"
+            "unique-filename": "^2.0.0"
           }
         },
         "chalk": {
@@ -20579,7 +21091,7 @@
           }
         },
         "diff": {
-          "version": "5.0.0",
+          "version": "5.1.0",
           "bundled": true,
           "dev": true
         },
@@ -20681,7 +21193,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "5.0.0",
+          "version": "5.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20689,7 +21201,7 @@
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true
         },
@@ -20767,7 +21279,7 @@
           "dev": true
         },
         "ini": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true
         },
@@ -20786,7 +21298,7 @@
           }
         },
         "ip": {
-          "version": "1.1.8",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -20804,7 +21316,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.9.0",
+          "version": "2.10.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20842,17 +21354,17 @@
           "dev": true
         },
         "just-diff": {
-          "version": "5.0.3",
+          "version": "5.1.1",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
-          "version": "5.3.1",
+          "version": "5.4.1",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
-          "version": "6.0.3",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20863,14 +21375,14 @@
           }
         },
         "libnpmdiff": {
-          "version": "4.0.4",
+          "version": "4.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/disparity-colors": "^2.0.0",
             "@npmcli/installed-package-contents": "^1.0.7",
             "binary-extensions": "^2.2.0",
-            "diff": "^5.0.0",
+            "diff": "^5.1.0",
             "minimatch": "^5.0.1",
             "npm-package-arg": "^9.0.1",
             "pacote": "^13.6.1",
@@ -20878,11 +21390,11 @@
           }
         },
         "libnpmexec": {
-          "version": "4.0.9",
+          "version": "4.0.14",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^5.0.0",
+            "@npmcli/arborist": "^5.6.3",
             "@npmcli/ci-detect": "^2.0.0",
             "@npmcli/fs": "^2.1.1",
             "@npmcli/run-script": "^4.2.0",
@@ -20899,15 +21411,15 @@
           }
         },
         "libnpmfund": {
-          "version": "3.0.2",
+          "version": "3.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^5.0.0"
+            "@npmcli/arborist": "^5.6.3"
           }
         },
         "libnpmhook": {
-          "version": "8.0.3",
+          "version": "8.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20916,7 +21428,7 @@
           }
         },
         "libnpmorg": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20925,7 +21437,7 @@
           }
         },
         "libnpmpack": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20935,7 +21447,7 @@
           }
         },
         "libnpmpublish": {
-          "version": "6.0.4",
+          "version": "6.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20947,7 +21459,7 @@
           }
         },
         "libnpmsearch": {
-          "version": "5.0.3",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20955,7 +21467,7 @@
           }
         },
         "libnpmteam": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20964,7 +21476,7 @@
           }
         },
         "libnpmversion": {
-          "version": "3.0.6",
+          "version": "3.0.7",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20976,12 +21488,12 @@
           }
         },
         "lru-cache": {
-          "version": "7.12.0",
+          "version": "7.13.2",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "10.2.0",
+          "version": "10.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21028,7 +21540,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21111,7 +21623,7 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "9.0.0",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21156,19 +21668,27 @@
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
+            },
+            "nopt": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "abbrev": "1"
+              }
             }
           }
         },
         "nopt": {
-          "version": "5.0.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1"
+            "abbrev": "^1.0.0"
           }
         },
         "normalize-package-data": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21187,11 +21707,18 @@
           }
         },
         "npm-bundled": {
-          "version": "1.1.2",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-install-checks": {
@@ -21219,25 +21746,39 @@
           }
         },
         "npm-packlist": {
-          "version": "5.1.1",
+          "version": "5.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^8.0.1",
             "ignore-walk": "^5.0.1",
-            "npm-bundled": "^1.1.2",
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-bundled": "^2.0.0",
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-pick-manifest": {
-          "version": "7.0.1",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-install-checks": "^5.0.0",
-            "npm-normalize-package-bin": "^1.0.1",
+            "npm-normalize-package-bin": "^2.0.0",
             "npm-package-arg": "^9.0.0",
             "semver": "^7.3.5"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-profile": {
@@ -21250,7 +21791,7 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "13.3.0",
+          "version": "13.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21301,7 +21842,7 @@
           }
         },
         "pacote": {
-          "version": "13.6.1",
+          "version": "13.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21408,14 +21949,21 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "5.0.1",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^8.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "normalize-package-data": "^4.0.0",
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "read-package-json-fast": {
@@ -21538,11 +22086,11 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.2",
+          "version": "2.7.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "^1.1.5",
+            "ip": "^2.0.0",
             "smart-buffer": "^4.2.0"
           }
         },
@@ -21655,15 +22203,15 @@
           "dev": true
         },
         "unique-filename": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "^3.0.0"
           }
         },
         "unique-slug": {
-          "version": "2.0.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21727,7 +22275,7 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22478,9 +23026,9 @@
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "shebang-command": {
           "version": "1.2.0",
@@ -22815,6 +23363,12 @@
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -23020,9 +23574,9 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "shebang-command": {
@@ -23125,7 +23679,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
           "dev": true
         }
       }
@@ -23177,9 +23731,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "type-fest": {
@@ -23322,12 +23876,12 @@
       "dev": true
     },
     "registry-auth-token": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+      "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.2.8"
+        "@pnpm/npm-conf": "^2.1.0"
       }
     },
     "release-zalgo": {
@@ -23479,7 +24033,7 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
       "dev": true
     },
     "scoped-regex": {
@@ -23542,9 +24096,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -23559,9 +24113,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -24453,6 +25007,19 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -24587,6 +25154,19 @@
         "path-exists": "^4.0.0"
       }
     },
+    "which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -24605,9 +25185,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wordwrap": {
@@ -24673,19 +25253,19 @@
       }
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       },
       "dependencies": {
         "xmlbuilder": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
           "dev": true
         }
       }

--- a/src/commands/set/android.ts
+++ b/src/commands/set/android.ts
@@ -7,7 +7,7 @@ export default class SetAndroid extends CustomCommand {
   static description = 'Set android version and build number';
   static examples = ['<%= config.bin %> <%= command.id %> /project/path -v 1.0.0-rc1 -b 10'];
 
-  static args = [...CustomCommand.args];;
+  static args = [...CustomCommand.args];
   static flags = { ...CustomCommand.flags };
 
   public async run(): Promise<VersionInfo> {

--- a/src/commands/set/android.ts
+++ b/src/commands/set/android.ts
@@ -7,7 +7,7 @@ export default class SetAndroid extends CustomCommand {
   static description = 'Set android version and build number';
   static examples = ['<%= config.bin %> <%= command.id %> /project/path -v 1.0.0-rc1 -b 10'];
 
-  static args = [...CustomCommand.args];
+  static args = [...CustomCommand.args];;
   static flags = { ...CustomCommand.flags };
 
   public async run(): Promise<VersionInfo> {

--- a/test/commands/set/index.test.ts
+++ b/test/commands/set/index.test.ts
@@ -87,6 +87,17 @@ describe('when capacitor-set-version is called', () => {
       .it('should error');
   });
 
+  describe('for android project with build.gradle.kts', () => {
+    test
+      .stdout()
+      .stderr()
+      .command(['set', '-v', versionInfo.version, '-b', versionInfo.build.toString(), MockFsFactory.DIR_ANDROID_KOTLIN])
+      .it('should set the android version', ctx => {
+        expect(ctx.stdout).to.be.empty;
+        expect(ctx.stderr).to.be.empty;
+      })
+  });
+
   describe('for android project without build.gradle file', () => {
     test
       .command([
@@ -114,7 +125,23 @@ describe('when capacitor-set-version is called', () => {
         MockFsFactory.DIR_NO_BUILD_GRADLE_VERSION,
       ])
       .catch(err => {
-        expect(err.message).to.contain('Could not find "versionName" in android/app/build.grade file');
+        expect(err.message).to.contain('Could not find "versionName" in android/app/build.grade(.kts) file');
+      })
+      .it('should error');
+  });
+
+  describe('for android project without build.gradle.kts version', () => {
+    test
+      .command([
+        'set',
+        '-v',
+        versionInfo.version,
+        '-b',
+        versionInfo.build.toString(),
+        MockFsFactory.DIR_NO_BUILD_GRADLE_VERSION_KOTLIN,
+      ])
+      .catch(err => {
+        expect(err.message).to.contain('Could not find "versionName" in android/app/build.grade(.kts) file');
       })
       .it('should error');
   });
@@ -130,7 +157,23 @@ describe('when capacitor-set-version is called', () => {
         MockFsFactory.DIR_NO_BUILD_GRADLE_BUILD,
       ])
       .catch(err => {
-        expect(err.message).to.contain('Could not find "versionCode" in android/app/build.grade file');
+        expect(err.message).to.contain('Could not find "versionCode" in android/app/build.grade(.kts) file');
+      })
+      .it('should error');
+  });
+
+  describe('for android project without build.gradle.kts build', () => {
+    test
+      .command([
+        'set',
+        '-v',
+        versionInfo.version,
+        '-b',
+        versionInfo.build.toString(),
+        MockFsFactory.DIR_NO_BUILD_GRADLE_BUILD_KOTLIN,
+      ])
+      .catch(err => {
+        expect(err.message).to.contain('Could not find "versionCode" in android/app/build.grade(.kts) file');
       })
       .it('should error');
   });

--- a/test/mockfs/build.gradle.kts
+++ b/test/mockfs/build.gradle.kts
@@ -1,0 +1,81 @@
+plugins {
+  id("com.android.application")
+  id("kotlin-android")
+}
+
+android {
+  namespace = "io.ionic.starter"
+  compileSdk = 34
+
+  defaultConfig {
+    applicationId = "io.ionic.starter"
+    minSdk = 23
+    targetSdk = 34
+    versionCode = 1
+    versionName = "0.0.1"
+    multiDexEnabled = true
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    androidResources {
+      ignoreAssetsPattern =
+        "!.idea:!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~"
+    }
+  }
+
+  buildTypes {
+    named("release") {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+
+  buildFeatures {
+    viewBinding = true
+  }
+  buildToolsVersion = "34.0.0"
+}
+
+repositories {
+  flatDir {
+    dirs("../capacitor-cordova-android-plugins/src/main/libs", "libs")
+  }
+}
+
+dependencies {
+  //  Android
+  implementation("androidx.annotation:annotation:1.7.0")
+  implementation("androidx.appcompat:appcompat:1.6.1")
+  implementation("androidx.coordinatorlayout:coordinatorlayout:1.2.0")
+  implementation("androidx.core:core-ktx:1.12.0")
+  implementation("androidx.core:core-splashscreen:1.0.1")
+  implementation("androidx.work:work-runtime:2.8.1")
+
+  //  Capacitor
+  implementation(project(":capacitor-android"))
+  implementation(project(":capacitor-cordova-android-plugins"))
+
+  // Testing dependencies
+  testImplementation("junit:junit:4.13.2")
+  androidTestImplementation("androidx.test.ext:junit:1.1.5")
+  androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}
+
+apply(from = "capacitor.build.gradle")
+apply(plugin = "org.jetbrains.kotlin.android")
+
+try {
+  val servicesJSON = File("google-services.json")
+  if (servicesJSON.isFile) {
+    apply(plugin = "com.google.gms.google-services")
+  }
+} catch (e: Exception) {
+  logger.info("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
+}

--- a/test/mockfs/build.gradle.kts.no-build
+++ b/test/mockfs/build.gradle.kts.no-build
@@ -1,0 +1,80 @@
+plugins {
+  id("com.android.application")
+  id("kotlin-android")
+}
+
+android {
+  namespace = "io.ionic.starter"
+  compileSdk = 34
+
+  defaultConfig {
+    applicationId = "io.ionic.starter"
+    minSdk = 23
+    targetSdk = 34
+    versionName = "1.0"
+    multiDexEnabled = true
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    androidResources {
+      ignoreAssetsPattern =
+        "!.idea:!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~"
+    }
+  }
+
+  buildTypes {
+    named("release") {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+
+  buildFeatures {
+    viewBinding = true
+  }
+  buildToolsVersion = "34.0.0"
+}
+
+repositories {
+  flatDir {
+    dirs("../capacitor-cordova-android-plugins/src/main/libs", "libs")
+  }
+}
+
+dependencies {
+  //  Android
+  implementation("androidx.annotation:annotation:1.7.0")
+  implementation("androidx.appcompat:appcompat:1.6.1")
+  implementation("androidx.coordinatorlayout:coordinatorlayout:1.2.0")
+  implementation("androidx.core:core-ktx:1.12.0")
+  implementation("androidx.core:core-splashscreen:1.0.1")
+  implementation("androidx.work:work-runtime:2.8.1")
+
+  //  Capacitor
+  implementation(project(":capacitor-android"))
+  implementation(project(":capacitor-cordova-android-plugins"))
+
+  // Testing dependencies
+  testImplementation("junit:junit:4.13.2")
+  androidTestImplementation("androidx.test.ext:junit:1.1.5")
+  androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}
+
+apply(from = "capacitor.build.gradle")
+apply(plugin = "org.jetbrains.kotlin.android")
+
+try {
+  val servicesJSON = File("google-services.json")
+  if (servicesJSON.isFile) {
+    apply(plugin = "com.google.gms.google-services")
+  }
+} catch (e: Exception) {
+  logger.info("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
+}

--- a/test/mockfs/build.gradle.kts.no-version
+++ b/test/mockfs/build.gradle.kts.no-version
@@ -1,0 +1,80 @@
+plugins {
+  id("com.android.application")
+  id("kotlin-android")
+}
+
+android {
+  namespace = "io.ionic.starter"
+  compileSdk = 34
+
+  defaultConfig {
+    applicationId = "io.ionic.starter"
+    minSdk = 23
+    targetSdk = 34
+    versionCode = 1
+    multiDexEnabled = true
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    androidResources {
+      ignoreAssetsPattern =
+        "!.idea:!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~"
+    }
+  }
+
+  buildTypes {
+    named("release") {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+
+  buildFeatures {
+    viewBinding = true
+  }
+  buildToolsVersion = "34.0.0"
+}
+
+repositories {
+  flatDir {
+    dirs("../capacitor-cordova-android-plugins/src/main/libs", "libs")
+  }
+}
+
+dependencies {
+  //  Android
+  implementation("androidx.annotation:annotation:1.7.0")
+  implementation("androidx.appcompat:appcompat:1.6.1")
+  implementation("androidx.coordinatorlayout:coordinatorlayout:1.2.0")
+  implementation("androidx.core:core-ktx:1.12.0")
+  implementation("androidx.core:core-splashscreen:1.0.1")
+  implementation("androidx.work:work-runtime:2.8.1")
+
+  //  Capacitor
+  implementation(project(":capacitor-android"))
+  implementation(project(":capacitor-cordova-android-plugins"))
+
+  // Testing dependencies
+  testImplementation("junit:junit:4.13.2")
+  androidTestImplementation("androidx.test.ext:junit:1.1.5")
+  androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}
+
+apply(from = "capacitor.build.gradle")
+apply(plugin = "org.jetbrains.kotlin.android")
+
+try {
+  val servicesJSON = File("google-services.json")
+  if (servicesJSON.isFile) {
+    apply(plugin = "com.google.gms.google-services")
+  }
+} catch (e: Exception) {
+  logger.info("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
+}

--- a/test/mockfs/mockfs.factory.ts
+++ b/test/mockfs/mockfs.factory.ts
@@ -6,9 +6,12 @@ export default class MockFsFactory {
   static DIR_NO_PROJECT = 'no_project';
   static DIR_NO_DIRECTORY = 'no_directory';
   static DIR_NO_ANDROID = 'no_android';
+  static DIR_ANDROID_KOTLIN = 'android_kotlin'
   static DIR_NO_BUILD_GRADLE = 'no_build_gradle';
   static DIR_NO_BUILD_GRADLE_VERSION = 'no_build_gradle_version';
-  static DIR_NO_BUILD_GRADLE_BUILD = 'no_build_gradle_build';
+  static DIR_NO_BUILD_GRADLE_VERSION_KOTLIN = 'no_build_gradle_version';
+  static DIR_NO_BUILD_GRADLE_BUILD = 'no_build_gradle_build_kotlin';
+  static DIR_NO_BUILD_GRADLE_BUILD_KOTLIN = 'no_build_gradle_build_kotlin';
   static DIR_NO_IOS = 'no_ios';
   static DIR_IOS_LEGACY = 'ios_legacy';
   static DIR_IOS_NO_INFO_PLIST = 'ios_no_info_plist';
@@ -51,6 +54,14 @@ export default class MockFsFactory {
           },
         },
       },
+      'android_kotlin': {
+        'capacitor.config.ts': mockfs.load(resolve(__dirname, '../mockfs/capacitor.config.ts')),
+        'android': {
+          app: {
+            'build.gradle': mockfs.load(resolve(__dirname, '../mockfs/build.gradle.kts')),
+          },
+        },
+      },
       'no_build_gradle': {
         'capacitor.config.ts': mockfs.load(resolve(__dirname, '../mockfs/capacitor.config.ts')),
         'android': {
@@ -65,11 +76,27 @@ export default class MockFsFactory {
           },
         },
       },
+      'no_build_gradle_version_kotlin': {
+        'capacitor.config.ts': mockfs.load(resolve(__dirname, '../mockfs/capacitor.config.ts')),
+        'android': {
+          app: {
+            'build.gradle': mockfs.load(resolve(__dirname, '../mockfs/build.gradle.kts.no-version')),
+          },
+        },
+      },
       'no_build_gradle_build': {
         'capacitor.config.ts': mockfs.load(resolve(__dirname, '../mockfs/capacitor.config.ts')),
         'android': {
           app: {
             'build.gradle': mockfs.load(resolve(__dirname, '../mockfs/build.gradle.no-build')),
+          },
+        },
+      },
+      'no_build_gradle_build_kotlin': {
+        'capacitor.config.ts': mockfs.load(resolve(__dirname, '../mockfs/capacitor.config.ts')),
+        'android': {
+          app: {
+            'build.gradle': mockfs.load(resolve(__dirname, '../mockfs/build.gradle.kts.no-build')),
           },
         },
       },


### PR DESCRIPTION
Gradle offers a new way to write `build.gradle` files using Kotlin (Gradle DSL) which requires files ending in: `kts`. See [here](https://docs.gradle.org/current/userguide/kotlin_dsl.html)  for more info on Gradle DSL. These currently do not work with this package. This PR aims to add support for these files. Apart from the file ending there are minor syntactic changes, like double quotes and equals.

I've tested this locally against a project that has a `build.gradle.kts` file using something like:
```sh
node ../capacitor-set-version/bin/dev ~/Developer/example -v 1.5.0 -b 150
```
And it worked as expected (with regular `build.gradle` and `build.gradle.kts` and an iOS project), however, I am unable to get the tests working. I haven't used this test suite before, but tried to replicate the other test cases. Unfortunately I could not get them to pass. Any advice on this would be appreciated.